### PR TITLE
Fixed setBackLED: does not break odometry any more

### DIFF
--- a/src/Asuro.cpp
+++ b/src/Asuro.cpp
@@ -169,13 +169,26 @@ void Asuro::setTimer2(void)
 //taillight LEDs
 void Asuro::setBackLED(unsigned char left, unsigned char right)
 {
-    if (left || right) {
-        PORTD &= ~(1 << PD7); // Wheel LED OFF
-        DDRC |= (1 << PC0) | (1 << PC1); // Output => no odometrie
-        PORTC |= (1 << PC0) | (1 << PC1);
-    }
-    if (!left) PORTC &= ~(1 << PC1);
-    if (!right) PORTC &= ~(1 << PC0);
+	if (left) {
+		PORTD &= ~(1 << PD7); // Wheel LED OFF
+		DDRC |= (1 << PC1); // Output => no odometrie
+		PORTC |= (1 << PC1);
+	}
+	else {
+		PORTD |= (1 << PD7); 
+		DDRC &=~ (1 << PC1); 
+		PORTC &=~ (1 << PC1);
+	}
+	if (right) {
+		PORTD &= ~(1 << PD7); // Wheel LED OFF
+		DDRC |= (1 << PC0); // Output => no odometrie
+		PORTC |= (1 << PC0);
+	}
+	else {
+		PORTD |= (1 << PD7); 
+		DDRC &=~ (1 << PC0); 
+		PORTC &=~ (1 << PC0);
+	}	
 }
 
 
@@ -225,14 +238,9 @@ int Asuro::readBattery(void)
 //read odometry
 void Asuro::readOdometry(int *data)
 {
-    uint8_t oldadmux = (ADMUX & (unsigned int) 0xf0);
-    ADMUX = (1 << REFS0) ;
-    DDRC &= ~((1 << PC0) | (1 << PC1));   // Back-LEDs off
     digitalWrite(odometricled, HIGH);
-    delayMicroseconds(10);
     data[LEFT] = analogRead(lodometric);
     data[RIGHT] = analogRead(rodometric);
-    ADMUX = oldadmux;
 }
 
 
@@ -297,6 +305,18 @@ void Asuro::setMotorDirection (int left, int right)
 //motor speed
 void Asuro::setMotorSpeed (int left, int right)
 {
+	left = constrain(left, -255, 255);
+	right = constrain(right, -255, 255);
+	int motorDirs[2] {FWD, FWD};
+	if (left < 0) {
+		left = -left;
+		motorDirs[LEFT] = RWD;
+	}
+	if (right < 0) {
+		right = -right;
+		motorDirs[RIGHT] = RWD;
+	}
+	Asuro::setMotorDirection(motorDirs[LEFT], motorDirs[RIGHT]);
     analogWrite(PWM_MOTOR_L, left);
     analogWrite(PWM_MOTOR_R, right);
 }


### PR DESCRIPTION
Improved setMotorSpeed: now accepts negative values and calls setMotorDirection accordingly. No need to call setMotorDirection separately any more. Removed unnecessary code in readOdometry.